### PR TITLE
fix(Whatsapp): Fix message "WhatsApp works with Google Chrome 36+"

### DIFF
--- a/whatsapp/index.js
+++ b/whatsapp/index.js
@@ -1,4 +1,8 @@
 "use strict";
 
-module.exports = Franz => Franz;
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIndoYXRzYXBwL2luZGV4LmpzIl0sIm5hbWVzIjpbIm1vZHVsZSIsImV4cG9ydHMiLCJGcmFueiJdLCJtYXBwaW5ncyI6Ijs7QUFBQUEsT0FBT0MsT0FBUCxHQUFpQkMsU0FBU0EsS0FBMUIiLCJmaWxlIjoid2hhdHNhcHAvaW5kZXguanMiLCJzb3VyY2VzQ29udGVudCI6WyJtb2R1bGUuZXhwb3J0cyA9IEZyYW56ID0+IEZyYW56O1xuIl19
+module.exports = Franz => class Messenger extends Franz {
+  overrideUserAgent() {
+    return window.navigator.userAgent.replace(/(Franz|Electron)([^\s]+\s)/g, '');
+  }
+
+};


### PR DESCRIPTION
As title says. Whatsapp has an issue in recent versions of Franz. The instructions in the official site says to update the recipes for that service. As that overrides the themes, and for what it seems only the index.js needs to be updated for it to work and have the dark theme, this is the file I change.